### PR TITLE
Add missing `.hash` to schema optional value.

### DIFF
--- a/workers/vulns.rb
+++ b/workers/vulns.rb
@@ -59,7 +59,7 @@ module Workers
         optional(:escape).maybe(Types::Vulns::SSTI::EscapeType)
       end
 
-      optional(:command_injection) do
+      optional(:command_injection).hash do
         optional(:escape_quote).maybe(:string)
         optional(:escape_operator).maybe(:string)
         optional(:terminate).maybe(:string)


### PR DESCRIPTION
Missing `.hash` here: https://github.com/ronin-rb/ronin-app/blob/39756743090a47900d36adf97169baf037999674/workers/vulns.rb#L62