### PR TITLE
Add `/db` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.swp
 *~
 dump.rdb
+/db


### PR DESCRIPTION
`/db` is created to store dev db so we can add it to `.gitignore` right?