### PR TITLE
Change `ignore` to be an optional recon argument

### DIFF
--- a/lib/ronin/app/validations/recon_params.rb
+++ b/lib/ronin/app/validations/recon_params.rb
@@ -38,8 +38,8 @@ module Ronin
 
         params do
           required(:scope).filled(Types::Args).each(:filled?)
-          optional(:ignore).filled(Types::Args).each(:filled?)
 
+          optional(:ignore).maybe(Types::Args)
           optional(:max_depth).maybe(:integer)
         end
 

--- a/spec/validations/recon_params_spec.rb
+++ b/spec/validations/recon_params_spec.rb
@@ -65,7 +65,7 @@ describe Ronin::App::Validations::ReconParams do
     end
 
     describe ":ignore" do
-      it "must require a non-empty value for :ignore" do
+      it "must not require a value for :ignore" do
         result = subject.call(
           {
             scope:  'example.com',
@@ -73,8 +73,7 @@ describe Ronin::App::Validations::ReconParams do
           }
         )
 
-        expect(result).to be_failure
-        expect(result.errors[:ignore]).to eq(["must be filled"])
+        expect(result).to be_success
       end
 
       it "must accept IP range(s)" do

--- a/workers/recon.rb
+++ b/workers/recon.rb
@@ -52,12 +52,14 @@ module Workers
     #   The params could not be validated or coerced.
     #
     def perform(params)
-      kwargs            = validate(params)
-      values            = kwargs[:scope].map(&Ronin::Recon::Value.method(:parse))
-      ignore            = []
-      if (ignore_kwargs = kwargs[:ignore])
-        ignore = ignore_kwargs.map(&Ronin::Recon::Value.method(:parse))
-      end
+      kwargs = validate(params)
+      values = kwargs[:scope].map(&Ronin::Recon::Value.method(:parse))
+
+      ignore = if (ignore_kwargs = kwargs[:ignore])
+                 ignore_kwargs.map(&Ronin::Recon::Value.method(:parse))
+               else
+                 []
+               end
 
       Ronin::Recon::Engine.run(values, ignore:    ignore,
                                        max_depth: kwargs[:max_depth]) do |engine|

--- a/workers/recon.rb
+++ b/workers/recon.rb
@@ -37,6 +37,8 @@ module Workers
     # The accepted JSON params which will be passed to {Recon#perform}.
     Params = Dry::Schema::JSON() do
       required(:scope).array(:string).each(:filled?)
+
+      optional(:ignore).maybe(:array)
       optional(:max_depth).maybe(:integer)
     end
 
@@ -50,9 +52,12 @@ module Workers
     #   The params could not be validated or coerced.
     #
     def perform(params)
-      kwargs  = validate(params)
-      values  = kwargs[:scope].map(&Ronin::Recon::Value.method(:parse))
-      ignore  = kwargs[:ignore].map(&Ronin::Recon::Value.method(:parse))
+      kwargs            = validate(params)
+      values            = kwargs[:scope].map(&Ronin::Recon::Value.method(:parse))
+      ignore            = []
+      if (ignore_kwargs = kwargs[:ignore])
+        ignore = ignore_kwargs.map(&Ronin::Recon::Value.method(:parse))
+      end
 
       Ronin::Recon::Engine.run(values, ignore:    ignore,
                                        max_depth: kwargs[:max_depth]) do |engine|


### PR DESCRIPTION
I am not sure if it will be out final version, but it's definitely more accurate than current solution as a ignore is an optional argument.